### PR TITLE
Sets links in body content to be underlined

### DIFF
--- a/css/global.scss
+++ b/css/global.scss
@@ -17,6 +17,15 @@ $loading: url(../../../images/loading.gif) center no-repeat;
 	width: 72.9%;
 }
 
+#content-main,
+#content,
+.content-main,
+.entry-content {
+	a {
+		text-decoration: underline;
+	}
+}
+
 .entry-content {
 	padding-left: $sectionBreakIE;
 	padding-left: $sectionBreak;

--- a/css/homepage.scss
+++ b/css/homepage.scss
@@ -18,10 +18,7 @@
 .page-template-page-moh-home-php .entry-content h3.heading,
 .page-template-page-moh-home-php .entry-content h3.heading a {
 	color: #424286;
-	text-decoration: none;
 }
-
-.page-template-page-moh-home-php .entry-content h3.heading a:hover { text-decoration: underline; }
 
 .page-template-page-moh-home-php .entry-content p:last-child { margin: 0; }
 

--- a/css/style.css
+++ b/css/style.css
@@ -5,7 +5,7 @@
  * Author:         Lightning and Trumpet
  * Author URI:     http://lightningandtrumpet.com/
  * Template:       libraries
- * Version:        1.2.0-@@branch-@@commit
+ * Version:        1.2.1-@@branch-@@commit
 */
 
 @import url( '../libraries/style.css' );
@@ -355,14 +355,6 @@ option.uppercase {
 
 .single-interviews #contents .column-3 {
 	text-align: right;
-}
-
-.single-interviews #contents a {
-	text-decoration: none;
-}
-
-.single-interviews #contents a:hover {
-	text-decoration: underline;
 }
 
 .single-interviews #contents .arrows {


### PR DESCRIPTION
#### Why are these changes being introduced:

* UX has requested that links in the body / content areas of this theme
  be underlined, overriding a rule that has been implemented in the
  parent theme (and sporadically in this theme) that links are plain by
  default, and underlined on hover.

#### How does this address that need:

* This removes a few style rules from around the theme that reinforce
  the plain/underlined-hover link style, and adds a hopefully-
  comprehensive set of rules to the global.scss stylesheet to set all
  links in the body of a page to display as underlined (hover state is
  left undefined, which will likely still be underlined).

#### Document any side effects to this change:

* Because the page templates in this theme do not consistently use a
  single set of class and id values, the added rule has a number of
  conditions (.content-main, #content-main, .entry-content, etc).

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-1229

#### Todo:
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
